### PR TITLE
Modernize ceres CMake linkage

### DIFF
--- a/camera_models/CMakeLists.txt
+++ b/camera_models/CMakeLists.txt
@@ -15,9 +15,7 @@ find_package(Boost REQUIRED COMPONENTS filesystem program_options system)
 include_directories(${Boost_INCLUDE_DIRS})
 
 find_package(OpenCV REQUIRED)
-find_package(Ceres REQUIRED)
-include_directories(${CERES_INCLUDE_DIRS})
-
+find_package(Ceres 2 REQUIRED)
 
 ament_export_include_directories(include)
 ament_export_libraries(camera_models)
@@ -64,8 +62,8 @@ add_library(camera_models
     src/gpl/gpl.cc
     src/gpl/EigenQuaternionParameterization.cc)
 
-target_link_libraries(Calibrations ${Boost_LIBRARIES} ${OpenCV_LIBS} ${CERES_LIBRARIES})
-target_link_libraries(camera_models ${Boost_LIBRARIES} ${OpenCV_LIBS} ${CERES_LIBRARIES})
+target_link_libraries(Calibrations ${Boost_LIBRARIES} ${OpenCV_LIBS} Ceres::ceres)
+target_link_libraries(camera_models ${Boost_LIBRARIES} ${OpenCV_LIBS} Ceres::ceres)
 
 
 # Install

--- a/global_fusion/CMakeLists.txt
+++ b/global_fusion/CMakeLists.txt
@@ -15,13 +15,11 @@ find_package(nav_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(visualization_msgs REQUIRED)
 
-find_package(Ceres REQUIRED)
+find_package(Ceres 2 REQUIRED)
 
 add_subdirectory(./ThirdParty/GeographicLib/)
 
 include_directories(
-  # ${catkin_INCLUDE_DIRS}
-  ${CERES_INCLUDE_DIRS}
   ./ThirdParty/GeographicLib/include/
 )
 
@@ -35,7 +33,7 @@ add_executable(global_fusion_node
 # added from DEBUG
 ament_target_dependencies(global_fusion_node rclcpp nav_msgs geometry_msgs sensor_msgs visualization_msgs rclpy)
 
-target_link_libraries(global_fusion_node ${CERES_LIBRARIES} libGeographiccc) # ${catkin_LIBRARIES})
+target_link_libraries(global_fusion_node Ceres::ceres libGeographiccc)
 
 
 # Install

--- a/loop_fusion/CMakeLists.txt
+++ b/loop_fusion/CMakeLists.txt
@@ -17,11 +17,11 @@ find_package(cv_bridge REQUIRED)
 find_package(camera_models REQUIRED)
 
 find_package(OpenCV)
-find_package(Ceres REQUIRED)
+find_package(Ceres 2 REQUIRED)
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 find_package(Eigen3)
 
-include_directories( ${CERES_INCLUDE_DIRS}  ${EIGEN3_INCLUDE_DIR}) #${catkin_INCLUDE_DIRS})
+include_directories(${EIGEN3_INCLUDE_DIR})
 
 
 
@@ -45,7 +45,7 @@ add_executable(loop_fusion_node
 # added from DEBUG
 ament_target_dependencies(loop_fusion_node camera_models rclcpp ament_index_cpp std_msgs sensor_msgs visualization_msgs nav_msgs cv_bridge OpenCV) # roslib) # does 'roslib' really need ??
 
-target_link_libraries(loop_fusion_node ${OpenCV_LIBS} ${CERES_LIBRARIES} ) #${catkin_LIBRARIES}  )
+target_link_libraries(loop_fusion_node ${OpenCV_LIBS} Ceres::ceres )
 
 
 

--- a/vins/CMakeLists.txt
+++ b/vins/CMakeLists.txt
@@ -22,9 +22,7 @@ find_package(image_transport REQUIRED)
 
 
 find_package(OpenCV REQUIRED)
-find_package(Ceres REQUIRED)
-
-include_directories(${CERES_INCLUDE_DIRS})
+find_package(Ceres 2 REQUIRED)
 
 # include camera_models
 include_directories("../camera_models/include")
@@ -53,7 +51,7 @@ add_library(vins_lib
     src/initial/initial_sfm.cpp
     src/initial/initial_ex_rotation.cpp
     src/featureTracker/feature_tracker.cpp)
-target_link_libraries(vins_lib  ${OpenCV_LIBS} ${CERES_LIBRARIES})
+target_link_libraries(vins_lib  ${OpenCV_LIBS} Ceres::ceres)
 
 ament_target_dependencies(vins_lib rclcpp rcpputils std_msgs visualization_msgs geometry_msgs nav_msgs tf2 tf2_ros cv_bridge camera_models image_transport)
 


### PR DESCRIPTION
* Require version 2
* Link the target rather than using CMake variables for includes and libs

Reference: http://ceres-solver.org/installation.html#using-ceres-with-cmake